### PR TITLE
Fix: tool_groups YAML structure when MCP enabled without RAG

### DIFF
--- a/charts/llama-stack-operator-instance/templates/configmap.yaml
+++ b/charts/llama-stack-operator-instance/templates/configmap.yaml
@@ -203,8 +203,9 @@ data:
         provider_id: sentence-transformers
         model_type: embedding
       {{- end }}
-    {{- if .Values.rag.enabled }}
+    {{- if or .Values.rag.enabled .Values.mcp.enabled }}
     tool_groups:
+    {{- if .Values.rag.enabled }}
     - toolgroup_id: insert_into_memory
       provider_id: rag-runtime
     {{- end }}
@@ -213,6 +214,7 @@ data:
       provider_id: model-context-protocol
       mcp_endpoint:
         uri: http://canopy-mcp-calendar-mcp-server:8080/sse
+    {{- end }}
     {{- end }}
     {{- if .Values.eval.enabled }}
     benchmarks: []


### PR DESCRIPTION
When mcp.enabled=true but rag.enabled=false, the tool_groups: key was not created, leaving the MCP toolgroup entry as a floating list item which caused YAML parsing errors.

Fixed by wrapping both RAG and MCP tool_groups entries in a single conditional that creates tool_groups: when either is enabled.