### PR TITLE
Do a pull before committing anything in a pipeline.

### DIFF
--- a/charts/canopy-doc-ingestion-pipeline/templates/tasks/update-test-values.yaml
+++ b/charts/canopy-doc-ingestion-pipeline/templates/tasks/update-test-values.yaml
@@ -32,6 +32,8 @@ spec:
       image: quay.io/redhat-cop/ubi8-git:latest
       script: |
         #!/bin/sh
+        # Refresh the local copy
+        git pull
         # Commit the changes :P
         git config --global user.email "tekton@mlops.bot.com"
         git config --global user.name "🐈 Tekton 🐈"

--- a/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
@@ -16,7 +16,7 @@ spec:
       image: quay.io/redhat-cop/ubi8-git:latest
       script: |
         #!/bin/sh
-
+        git pull
         git config --global user.email "tekton@mlops.bot.com"
         git config --global user.name "🐈 Tekton 🐈"
         git config --global push.default simple


### PR DESCRIPTION
Since the same pipelines are triggered by various events, and because students might want to "attend to the forgotten PRs" while a pipeline is running, it can easily happen that by the time a PR is ready to be raised, there will have been commits ahead of what the git-clone task produced. This just makes sure we pull before committing/pushing anything.