### PR TITLE
Retain valid YAML if regex is disabled

### DIFF
--- a/charts/llama-stack-operator-instance/Chart.yaml
+++ b/charts/llama-stack-operator-instance/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for Llama Stack Operator instances 🦙
 name: llama-stack-operator-instance
 type: application
-version: 1.1.44
+version: 1.1.45
 appVersion: "latest"
 home: https://rhoai-genaiops.github.io/genaiops/
 icon: https://aiagentframeworks.ai/content/images/2024/11/llama-stack.png

--- a/charts/llama-stack-operator-instance/templates/configmap.yaml
+++ b/charts/llama-stack-operator-instance/templates/configmap.yaml
@@ -39,8 +39,8 @@ data:
             orchestrator_url: https://guardrails-orchestrator:8080
             verify_ssl: false
       {{- end }}
-          {{- if .Values.guardrails.regex.enabled }}
             shields:
+      {{- if .Values.guardrails.regex.enabled }}
               regex:
                 detectors:
                   regex_competitor:


### PR DESCRIPTION
If you disable guardrails.regex, the hap has no parent - invalid YAML 

(╯°□°）╯︵ ┻━┻ !!!

@RHRolun @ckavili 