### PR TITLE
Correct taskRef for canopy-evals-pipeline

### DIFF
--- a/charts/canopy-evals-pipeline/Chart.yaml
+++ b/charts/canopy-evals-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: canopy-evals-pipeline
 description: A Helm chart for Canopy Evals Pipeline using Tekton and Kubeflow
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: "1.0"
 keywords:
   - tekton

--- a/charts/canopy-evals-pipeline/Chart.yaml
+++ b/charts/canopy-evals-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: canopy-evals-pipeline
 description: A Helm chart for Canopy Evals Pipeline using Tekton and Kubeflow
 type: application
-version: 0.0.11
+version: 0.0.12
 appVersion: "1.0"
 keywords:
   - tekton

--- a/charts/canopy-evals-pipeline/templates/pipelines/pipeline.yaml
+++ b/charts/canopy-evals-pipeline/templates/pipelines/pipeline.yaml
@@ -157,7 +157,7 @@ spec:
       taskRef:
         name: tool-unit-tests-task
       runAfter:
-        - fetch-backend-repository
+        - git-clone
       workspaces:
         - name: output
           workspace: shared-workspace


### PR DESCRIPTION
Incorrect taskRef is causing an ArgoCD sync issue:

<img width="1906" height="193" alt="image" src="https://github.com/user-attachments/assets/79813d51-9974-4d01-b391-cb6f9a4c4e00" />
