### PR TITLE
Allow milvus.namespace override in llama-stack chart

### DIFF
--- a/charts/llama-stack-operator-instance/templates/configmap.yaml
+++ b/charts/llama-stack-operator-instance/templates/configmap.yaml
@@ -86,7 +86,7 @@ data:
       - provider_id: milvus
         provider_type: remote::milvus
         config:
-          uri: "http://{{ .Values.rag.milvus.service | default "milvus" }}.{{ .Release.Namespace }}.svc.cluster.local:19530"
+          uri: "http://{{ .Values.rag.milvus.service | default "milvus" }}.{{ .Values.rag.milvus.namespace | default .Release.Namespace }}.svc.cluster.local:19530"
           token: "root:Milvus"
           persistence:
             backend: kv_default

--- a/charts/llama-stack-operator-instance/values.schema.json
+++ b/charts/llama-stack-operator-instance/values.schema.json
@@ -120,6 +120,10 @@
                 "milvus-test",
                 "milvus-prod"
               ]
+            },
+            "namespace": {
+              "type": "string",
+              "description": "Namespace where Milvus runs (defaults to release namespace)"
             }
           },
           "required": ["service"],


### PR DESCRIPTION
## Summary

- Add optional `namespace` field to `rag.milvus` in the llama-stack-operator-instance chart
- Template uses `{{ .Values.rag.milvus.namespace | default .Release.Namespace }}` for the Milvus URI
- Backwards compatible: omitting namespace preserves existing behavior

## Problem

When llama-stack deploys to `{user}-canopy` but Milvus runs in `{user}-test`, the Milvus URI resolves to the wrong namespace because the template hardcodes `.Release.Namespace`.

Companion PR: https://github.com/rhoai-genaiops/lab-runner/pull/7