### PR TITLE
feat(evals-pipeline): raise PR to prod with vector_db_id after evals pass

### DIFF
--- a/charts/canopy-doc-ingestion-pipeline/Chart.yaml
+++ b/charts/canopy-doc-ingestion-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: canopy-doc-ingestion-pipeline
 description: A Helm chart for Canopy Doc Ingestion Pipeline using Tekton and Kubeflow
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "1.0"
 keywords:
   - tekton

--- a/charts/canopy-doc-ingestion-pipeline/templates/tasks/update-test-values.yaml
+++ b/charts/canopy-doc-ingestion-pipeline/templates/tasks/update-test-values.yaml
@@ -40,6 +40,6 @@ spec:
         git config --global push.default simple
         git config --global --add safe.directory '*'
         git add config.yaml
-        git commit -m "🚀 AUTOMATED COMMIT - Vector DB ID has updated 🚀" || rc=$?
+        git commit -m "🚀 AUTOMATED COMMIT - vector_db_id=$(params.VECTOR_DB_ID) 🚀" || rc=$?
         git remote set-url origin $(cat $HOME/.git-credentials)/$(params.USERNAME)/genaiops-gitops.git
         git push origin HEAD:main

--- a/charts/canopy-evals-pipeline/Chart.yaml
+++ b/charts/canopy-evals-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: canopy-evals-pipeline
 description: A Helm chart for Canopy Evals Pipeline using Tekton and Kubeflow
 type: application
-version: 0.0.12
+version: 0.0.13
 appVersion: "1.0"
 keywords:
   - tekton

--- a/charts/canopy-evals-pipeline/templates/pipelines/pipeline.yaml
+++ b/charts/canopy-evals-pipeline/templates/pipelines/pipeline.yaml
@@ -23,6 +23,10 @@ spec:
       type: string
       default: "latest"
       description: Short Git commit hash
+    - name: VECTOR_DB_ID
+      type: string
+      default: ""
+      description: Vector DB ID extracted from the triggering commit, promoted to prod once evals pass
     - name: BACKEND_URL
       type: string
       default: {{ .Values.kfp.backendUrl | quote }}
@@ -190,19 +194,50 @@ spec:
           workspace: shared-workspace
 {{- end }}
 
-    # # Update model version in Git
-    # - name: raise-pr-to-prod
-    #   taskRef:
-    #     name: raise-pr
-    #     kind: Task
-    #   runAfter:
-    #     - fetch-backend-repository
-# {{- if .Values.testing.enableUnitTests }}
-#         - tool-unit-tests
-# {{- end }}
-#       workspaces:
-#         - name: output
-#           workspace: shared-workspace
-#       params:
-#         - name: WORK_DIRECTORY
-#           value: "backend/main/chart"
+    # Clone the gitops repo so we can raise a PR against the prod config
+    - name: clone-gitops-repo
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: namespace
+            value: openshift-pipelines
+      runAfter:
+        - git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: URL
+          value: "https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/{{ .Values.USER_NAME }}/genaiops-gitops.git"
+        - name: REVISION
+          value: "main"
+        - name: SUBDIRECTORY
+          value: "genaiops-gitops"
+        - name: DELETE_EXISTING
+          value: "true"
+        - name: SSL_VERIFY
+          value: "false"
+
+    # Update model version in Git
+    - name: raise-pr-to-prod
+      taskRef:
+        name: raise-pr
+        kind: Task
+      runAfter:
+        - kfp-evaluation-task
+        - guidellm-task
+        - clone-gitops-repo
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: WORK_DIRECTORY
+          value: "genaiops-gitops/canopy/prod/backend"
+        - name: USERNAME
+          value: "{{ .Values.USER_NAME }}"
+        - name: VECTOR_DB_ID
+          value: "$(params.VECTOR_DB_ID)"

--- a/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
@@ -10,32 +10,57 @@ spec:
     - name: WORK_DIRECTORY
       description: Directory to start build in (handle multiple branches)
       type: string
+    - name: USERNAME
+      description: Name of the team that doing this exercise :)
+      type: string
+    - name: VECTOR_DB_ID
+      description: Vector DB ID to promote to prod. If empty, no PR is raised.
+      type: string
   steps:
     - name: patch-vector-db-id
+      workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
+      image: quay.io/redhat-cop/tekton-task-helm:3.6.3
+      script: |
+        #!/bin/sh
+        vector_db_id="$(params.VECTOR_DB_ID)"
+
+        if [ -z "${vector_db_id}" ]; then
+          echo "⏭️  No VECTOR_DB_ID provided, nothing to promote to prod. Skipping."
+          exit 0
+        fi
+
+        yq eval -i .information-search.vector_db_id=\"${vector_db_id}\" config.yaml
+
+    - name: commit-and-raise-pr
       workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
       image: quay.io/redhat-cop/ubi8-git:latest
       script: |
         #!/bin/sh
+        vector_db_id="$(params.VECTOR_DB_ID)"
+
+        if [ -z "${vector_db_id}" ]; then
+          echo "⏭️  No VECTOR_DB_ID provided, nothing to promote to prod. Skipping."
+          exit 0
+        fi
+
         git pull
         git config --global user.email "tekton@mlops.bot.com"
         git config --global user.name "🐈 Tekton 🐈"
         git config --global push.default simple
         git config --global --add safe.directory '*'
-        branch_name=genaiops_$(date +%Y_%m_%d_%H_%M)
-        git checkout -b $branch_name
-        cp values-test.yaml values-prod.yaml
-        git add values-prod.yaml
-        git commit -m "🚀 AUTOMATED COMMIT - Production prompt is updated" || rc=$?
-        git remote set-url origin $(cat $HOME/.git-credentials)/{{ .Values.USER_NAME }}/backend.git
-        git push origin $branch_name
-        curl --location 'https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/api/v1/repos/{{ .Values.USER_NAME }}/backend/pulls' --user 'opentlc-mgr:myPassw0rd' --header 'accept: application/json' --header 'Content-Type: application/json' \
+        branch_name=promote-${vector_db_id}
+        git checkout -b ${branch_name}
+        git add config.yaml
+        git commit -m "🚀 AUTOMATED COMMIT - promote vector_db_id=${vector_db_id} to prod 🚀" || rc=$?
+        git remote set-url origin $(cat $HOME/.git-credentials)/$(params.USERNAME)/genaiops-gitops.git
+        git push origin ${branch_name}
+        curl --location "https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/api/v1/repos/$(params.USERNAME)/genaiops-gitops/pulls" --user 'opentlc-mgr:myPassw0rd' --header 'accept: application/json' --header 'Content-Type: application/json' \
           --data '{
-              "assignee": "{{ .Values.USER_NAME }}",
+              "assignee": "$(params.USERNAME)",
               "base": "main",
-              "body": "Evaluation results can be found in [Prompt Tracker](https://prompt-tracker-ai501.{{ .Values.CLUSTER_DOMAIN }}/{{ .Values.USER_NAME }}/{{ .Values.CLUSTER_DOMAIN }}).",
+              "body": "This PR promotes `vector_db_id: '"${vector_db_id}"'` to prod after it passed the evals pipeline.\n\nEvaluation results will be added to this PR in a follow-up. In the meantime, check [Prompt Tracker](https://prompt-tracker-ai501.{{ .Values.CLUSTER_DOMAIN }}/$(params.USERNAME)/{{ .Values.CLUSTER_DOMAIN }}) for details.",
               "head": "'${branch_name}'",
-              "title": "🚀 AUTOMATED PR - Production prompts updates 🚀"
+              "title": "🚀 AUTOMATED PR - Promote vector_db_id '"${vector_db_id}"' to prod 🚀"
           }'
 
-          echo "☘️ A pull request is raised for prod: https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/{{ .Values.USER_NAME }}/backend/pulls/"
-  
+        echo "☘️ A pull request is raised for prod: https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/$(params.USERNAME)/genaiops-gitops/pulls/"

--- a/charts/canopy-evals-pipeline/templates/triggers/triggers.yaml
+++ b/charts/canopy-evals-pipeline/templates/triggers/triggers.yaml
@@ -85,7 +85,7 @@ spec:
         name: "cel"
       params:
         - name: filter
-          value: (body.ref == 'refs/heads/main') && (header.match('X-GitHub-Event', 'push')) && ((body.repository.name == 'evals') || ((body.repository.name == 'genaiops-gitops') && body.commits.exists(c, c.modified.exists(m, m == 'canopy/test/backend/config.yaml'))))
+          value: (body.ref == 'refs/heads/main') && (header.match('X-GitHub-Event', 'push') || header.match('X-Gitea-Event', 'push')) && ((body.repository.name == 'evals') || ((body.repository.name == 'genaiops-gitops') && body.commits.exists(c, c.modified.exists(m, m == 'canopy/test/backend/config.yaml'))))
         - name: overlays
           value:
           - expression: body.head_commit.id.truncate(7)

--- a/charts/canopy-evals-pipeline/templates/triggers/triggers.yaml
+++ b/charts/canopy-evals-pipeline/templates/triggers/triggers.yaml
@@ -17,6 +17,9 @@ spec:
     - name: git-ref
       description: The full git ref
       default: refs/heads/main
+    - name: vector-db-id
+      description: Vector DB ID extracted from the triggering commit message
+      default: ""
     - name: webhook-action
       default: ""
     - name: webhook-entity
@@ -44,6 +47,8 @@ spec:
         params:
           - name: GIT_SHORT_REVISION
             value: $(tt.params.git-short-revision)
+          - name: VECTOR_DB_ID
+            value: $(tt.params.vector-db-id)
           - name: BACKEND_URL
             value: {{ .Values.kfp.backendUrl | quote }}
           - name: LLM_ENDPOINT
@@ -87,11 +92,15 @@ spec:
             key: truncated_sha
           - expression: body.ref.split('/')[2]
             key: branch_name
+          - expression: "body.head_commit.message.contains('vector_db_id=') ? body.head_commit.message.split('vector_db_id=')[1].split(' ')[0] : ''"
+            key: vector_db_id
   bindings:
     - name: git-ref
       value: $(body.ref)
     - name: git-short-revision
       value: $(extensions.truncated_sha)
+    - name: vector-db-id
+      value: $(extensions.vector_db_id)
   template:
     ref: canopy-evals-trigger-template
 


### PR DESCRIPTION
## Summary
- Propagate `vector_db_id` from `canopy-doc-ingestion-pipeline` to `canopy-evals-pipeline` via the triggering commit message (race-condition safe: each evals run keeps the exact vector_db_id from its own triggering commit, even if a newer ingestion run pushes before it finishes)
- `update-test-values-task` now embeds `vector_db_id` in the commit message pushed to `genaiops-gitops`
- `canopy-evals-git-trigger` extracts `vector_db_id` via a CEL overlay (safely falls back to `""` when the trigger fires from the `evals` repo, where no such value exists) and passes it through the `TriggerTemplate`/`PipelineRun`
- `canopy-evals-pipeline` now clones `genaiops-gitops` and, once `kfp-evaluation-task` and `guidellm-task` finish, raises a PR promoting `vector_db_id` to the prod config via the rewritten `raise-pr` task
- Bumped chart versions for `canopy-doc-ingestion-pipeline` (0.0.9 -> 0.0.10) and `canopy-evals-pipeline` (0.0.12 -> 0.0.13)

This is **Phase 1** of a two-phase effort. Evaluation metrics are **not yet included** in the PR body (only a link to Prompt Tracker + a placeholder note); Phase 2 will extend `kfp-evaluation-task` to capture the real KFP evaluation results and embed them in this PR.

## Dependencies
This PR depends on https://github.com/rhoai-genaiops/lab-instructions/pull/183

## Test plan
- [x] `helm lint` passed for both `canopy-doc-ingestion-pipeline` and `canopy-evals-pipeline`
- [x] `helm template` rendered correctly for both charts, verified param propagation (`VECTOR_DB_ID`) end-to-end from trigger to `raise-pr` task

## Test evidence

<img width="1135" height="501" alt="image" src="https://github.com/user-attachments/assets/f74e3f8d-d9e0-4834-afef-c945a9bd4284" />

<img width="772" height="294" alt="image" src="https://github.com/user-attachments/assets/766ca3a7-bd74-4b11-922e-129f96062624" />

<img width="1329" height="547" alt="image" src="https://github.com/user-attachments/assets/5341701c-c882-40ed-a6bb-3985c1b88d5c" />


Made with [Cursor](https://cursor.com)