### PR TITLE
feat(evals-pipeline): embed evaluation metrics and links in automated PR body

### DIFF
--- a/charts/canopy-doc-ingestion-pipeline/Chart.yaml
+++ b/charts/canopy-doc-ingestion-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: canopy-doc-ingestion-pipeline
 description: A Helm chart for Canopy Doc Ingestion Pipeline using Tekton and Kubeflow
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "1.0"
 keywords:
   - tekton

--- a/charts/canopy-doc-ingestion-pipeline/templates/tasks/update-test-values.yaml
+++ b/charts/canopy-doc-ingestion-pipeline/templates/tasks/update-test-values.yaml
@@ -40,6 +40,6 @@ spec:
         git config --global push.default simple
         git config --global --add safe.directory '*'
         git add config.yaml
-        git commit -m "🚀 AUTOMATED COMMIT - Vector DB ID has updated 🚀" || rc=$?
+        git commit -m "🚀 AUTOMATED COMMIT - vector_db_id=$(params.VECTOR_DB_ID) 🚀" || rc=$?
         git remote set-url origin $(cat $HOME/.git-credentials)/$(params.USERNAME)/genaiops-gitops.git
         git push origin HEAD:main

--- a/charts/canopy-evals-pipeline/Chart.yaml
+++ b/charts/canopy-evals-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: canopy-evals-pipeline
 description: A Helm chart for Canopy Evals Pipeline using Tekton and Kubeflow
 type: application
-version: 0.0.12
+version: 0.0.13
 appVersion: "1.0"
 keywords:
   - tekton

--- a/charts/canopy-evals-pipeline/templates/pipelines/pipeline.yaml
+++ b/charts/canopy-evals-pipeline/templates/pipelines/pipeline.yaml
@@ -241,3 +241,5 @@ spec:
           value: "{{ .Values.USER_NAME }}"
         - name: VECTOR_DB_ID
           value: "$(params.VECTOR_DB_ID)"
+        - name: GIT_SHORT_REVISION
+          value: "$(params.GIT_SHORT_REVISION)"

--- a/charts/canopy-evals-pipeline/templates/pipelines/pipeline.yaml
+++ b/charts/canopy-evals-pipeline/templates/pipelines/pipeline.yaml
@@ -23,6 +23,10 @@ spec:
       type: string
       default: "latest"
       description: Short Git commit hash
+    - name: VECTOR_DB_ID
+      type: string
+      default: ""
+      description: Vector DB ID extracted from the triggering commit, promoted to prod once evals pass
     - name: BACKEND_URL
       type: string
       default: {{ .Values.kfp.backendUrl | quote }}
@@ -190,19 +194,50 @@ spec:
           workspace: shared-workspace
 {{- end }}
 
-    # # Update model version in Git
-    # - name: raise-pr-to-prod
-    #   taskRef:
-    #     name: raise-pr
-    #     kind: Task
-    #   runAfter:
-    #     - fetch-backend-repository
-# {{- if .Values.testing.enableUnitTests }}
-#         - tool-unit-tests
-# {{- end }}
-#       workspaces:
-#         - name: output
-#           workspace: shared-workspace
-#       params:
-#         - name: WORK_DIRECTORY
-#           value: "backend/main/chart"
+    # Clone the gitops repo so we can raise a PR against the prod config
+    - name: clone-gitops-repo
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: namespace
+            value: openshift-pipelines
+      runAfter:
+        - git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: URL
+          value: "https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/{{ .Values.USER_NAME }}/genaiops-gitops.git"
+        - name: REVISION
+          value: "main"
+        - name: SUBDIRECTORY
+          value: "genaiops-gitops"
+        - name: DELETE_EXISTING
+          value: "true"
+        - name: SSL_VERIFY
+          value: "false"
+
+    # Update model version in Git
+    - name: raise-pr-to-prod
+      taskRef:
+        name: raise-pr
+        kind: Task
+      runAfter:
+        - kfp-evaluation-task
+        - guidellm-task
+        - clone-gitops-repo
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: WORK_DIRECTORY
+          value: "genaiops-gitops/canopy/prod/backend"
+        - name: USERNAME
+          value: "{{ .Values.USER_NAME }}"
+        - name: VECTOR_DB_ID
+          value: "$(params.VECTOR_DB_ID)"

--- a/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
@@ -545,9 +545,7 @@ spec:
 
         lines.append("")
         git_hash = "$(params.GIT_SHORT_REVISION)"
-        import base64
-        minio_path_b64 = base64.b64encode(f"{git_hash}/".encode()).decode()
-        lines.append(f"> Detailed reports: [MinIO Test Results](https://minio-ui-{{ .Values.USER_NAME }}-toolings.{{ .Values.CLUSTER_DOMAIN }}/browser/test-results/{minio_path_b64})")
+        lines.append(f"> Detailed reports: [MinIO Test Results](https://minio-ui-{{ .Values.USER_NAME }}-toolings.{{ .Values.CLUSTER_DOMAIN }}/browser/test-results) (folder: `{git_hash}`)")
         lines.append("")
 
         with open(summary_path, "w") as f:

--- a/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
@@ -545,7 +545,9 @@ spec:
 
         lines.append("")
         git_hash = "$(params.GIT_SHORT_REVISION)"
-        lines.append(f"> Detailed reports: [MinIO Test Results](https://minio-ui-{{ .Values.USER_NAME }}-toolings.{{ .Values.CLUSTER_DOMAIN }}/browser/test-results/{git_hash}/)")
+        import base64
+        minio_path_b64 = base64.b64encode(f"{git_hash}/".encode()).decode()
+        lines.append(f"> Detailed reports: [MinIO Test Results](https://minio-ui-{{ .Values.USER_NAME }}-toolings.{{ .Values.CLUSTER_DOMAIN }}/browser/test-results/{minio_path_b64})")
         lines.append("")
 
         with open(summary_path, "w") as f:

--- a/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
@@ -544,7 +544,7 @@ spec:
                     lines.append(f"| /{endpoint_name} | - | - | - | - | ERROR: {e} |")
 
         lines.append("")
-        lines.append("> Detailed reports: [Prompt Tracker](https://prompt-tracker-ai501.{{ .Values.CLUSTER_DOMAIN }}/{{ .Values.USER_NAME }}/{{ .Values.CLUSTER_DOMAIN }})")
+        lines.append("> Detailed reports: [MinIO Test Results](https://minio-ui-{{ .Values.USER_NAME }}-toolings.{{ .Values.CLUSTER_DOMAIN }}/browser/test-results)")
         lines.append("")
 
         with open(summary_path, "w") as f:

--- a/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
@@ -496,6 +496,8 @@ spec:
         #!/bin/bash
         set -e
 
+        pip install -q pyyaml
+
         echo "📊 Generating markdown eval summary from benchmark YAML files..."
 
         python3 << 'PYEOF'

--- a/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
@@ -489,3 +489,66 @@ spec:
         
         print("S3 upload completed successfully!")
         EOF
+    - name: generate-eval-summary
+      image: "registry.access.redhat.com/ubi9/python-311"
+      workingDir: "$(workspaces.shared-workspace.path)"
+      script: |
+        #!/bin/bash
+        set -e
+
+        echo "📊 Generating markdown eval summary from benchmark YAML files..."
+
+        python3 << 'PYEOF'
+        import yaml
+        import glob
+        import os
+
+        workspace_path = "$(workspaces.shared-workspace.path)"
+        summary_path = os.path.join(workspace_path, "guidellm_eval_summary.md")
+
+        yaml_files = sorted(glob.glob("guidellm_*_results.yaml"))
+
+        lines = []
+        lines.append("### GuideLLM Benchmarks\n")
+        lines.append("| Endpoint | Req/s | Output Tok/s | TTFT (ms) | Latency (s) | Status |")
+        lines.append("|----------|-------|-------------|-----------|-------------|--------|")
+
+        if not yaml_files:
+            lines.append("| - | - | - | - | - | No results |")
+        else:
+            for yaml_file in yaml_files:
+                endpoint_name = yaml_file.replace("guidellm_", "").replace("_results.yaml", "").replace("_", "/")
+                try:
+                    with open(yaml_file) as f:
+                        data = yaml.safe_load(f)
+
+                    b = data["benchmarks"][0]
+                    m = b["metrics"]
+                    totals = b["request_totals"]
+
+                    req_per_sec = m["requests_per_second"]["successful"]["mean"]
+                    out_tok_sec = m["output_tokens_per_second"]["successful"]["mean"]
+                    ttft = m["time_to_first_token_ms"]["successful"]["mean"]
+                    latency = m["request_latency"]["successful"]["mean"]
+
+                    success_pct = totals["successful"] / totals["total"] * 100 if totals["total"] else 0
+                    status = "PASS" if success_pct >= 80 else "FAIL"
+
+                    lines.append(
+                        f"| /{endpoint_name} | {req_per_sec:.3f} | {out_tok_sec:.1f} "
+                        f"| {ttft:.0f} | {latency:.2f} | {status} |"
+                    )
+                except Exception as e:
+                    lines.append(f"| /{endpoint_name} | - | - | - | - | ERROR: {e} |")
+
+        lines.append("")
+        lines.append("> Detailed reports: [Prompt Tracker](https://prompt-tracker-ai501.{{ .Values.CLUSTER_DOMAIN }}/{{ .Values.USER_NAME }}/{{ .Values.CLUSTER_DOMAIN }})")
+        lines.append("")
+
+        with open(summary_path, "w") as f:
+            f.write("\n".join(lines))
+
+        print(f"✅ GuideLLM eval summary written to {summary_path}")
+        print("Content:")
+        print("\n".join(lines))
+        PYEOF

--- a/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/guidellm-task.yaml
@@ -544,7 +544,8 @@ spec:
                     lines.append(f"| /{endpoint_name} | - | - | - | - | ERROR: {e} |")
 
         lines.append("")
-        lines.append("> Detailed reports: [MinIO Test Results](https://minio-ui-{{ .Values.USER_NAME }}-toolings.{{ .Values.CLUSTER_DOMAIN }}/browser/test-results)")
+        git_hash = "$(params.GIT_SHORT_REVISION)"
+        lines.append(f"> Detailed reports: [MinIO Test Results](https://minio-ui-{{ .Values.USER_NAME }}-toolings.{{ .Values.CLUSTER_DOMAIN }}/browser/test-results/{git_hash}/)")
         lines.append("")
 
         with open(summary_path, "w") as f:

--- a/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
@@ -161,7 +161,7 @@ spec:
                     val = m["value"]
                     val_str = f"{val:.4f}" if isinstance(val, float) else str(val)
                     lines.append(f"| {exp_name} | {run_name} | {m['key']} | {val_str} |")
-                exp_links.append(f"- [{exp_name}](https://rh-ai.{{ .Values.CLUSTER_DOMAIN }}/develop-train/mlflow/experiments/{exp_id}/runs/{mlflow_run_id}/evaluations?workspace={namespace})")
+                exp_links.append(f"- [{exp_name}](https://rh-ai.{{ .Values.CLUSTER_DOMAIN }}/develop-train/mlflow/experiments/{exp_id}/runs/{mlflow_run_id}?workspace={namespace})")
 
             if not found_runs:
                 lines.append(f"| - | - | No runs found for git_hash={git_hash} | - |")

--- a/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
@@ -37,14 +37,15 @@ spec:
 
         ls -latr
 
-        echo "Installing KFP dependencies..."
-        python3 -m pip install kfp==2.14.6 kfp.kubernetes==2.14.6
+        echo "Installing KFP and MLflow dependencies..."
+        python3 -m pip install kfp==2.14.6 kfp.kubernetes==2.14.6 mlflow==2.21.3
 
         echo "Executing Kubeflow Pipeline..."
         python3 << 'PYEOF'
         import kfp
         import sys
         import os
+        import time
 
         sys.path.insert(0, '.')
 
@@ -69,13 +70,16 @@ spec:
             ssl_ca_cert=ssl_ca_cert
         )
 
+        git_hash = "$(params.GIT_SHORT_REVISION)"
+        mlflow_tracking_uri = "https://mlflow.redhat-ods-applications.svc.cluster.local:8443"
+
         arguments = {
             "repo_url": "$(params.GIT_URL)",
             "branch": "$(params.GIT_BRANCH)",
             "backend_url": "$(params.BACKEND_URL)",
             "llm_endpoint": "$(params.LLM_ENDPOINT)",
-            "mlflow_tracking_uri": "https://mlflow.redhat-ods-applications.svc.cluster.local:8443",
-            "git_hash": "$(params.GIT_SHORT_REVISION)",
+            "mlflow_tracking_uri": mlflow_tracking_uri,
+            "git_hash": git_hash,
         }
 
         print(f"Arguments for the pipeline: {arguments}")
@@ -98,6 +102,62 @@ spec:
 
         print(f"🎉 Pipeline run created with ID: {run_id.run_id}")
         print("✅ Kubeflow Pipeline execution completed successfully!")
+
+        # --- Phase 2: Query MLflow for evaluation metrics ---
+        print("📊 Querying MLflow for evaluation metrics...")
+        time.sleep(30)  # Allow MLflow to flush all metrics
+
+        workspace_path = "$(workspaces.output.path)"
+        summary_path = os.path.join(workspace_path, "kfp_eval_summary.md")
+
+        try:
+            import mlflow
+            from mlflow.tracking import MlflowClient
+
+            os.environ["MLFLOW_TRACKING_URI"] = mlflow_tracking_uri
+            os.environ["MLFLOW_TRACKING_TOKEN"] = bearer_token
+
+            mlflow_client = MlflowClient(tracking_uri=mlflow_tracking_uri)
+
+            experiments = mlflow_client.search_experiments()
+            lines = []
+            lines.append("### KFP Evaluations (MLflow)\n")
+            lines.append("| Experiment | Run | Metric | Value |")
+            lines.append("|------------|-----|--------|-------|")
+
+            found_runs = False
+            for exp in experiments:
+                runs = mlflow_client.search_runs(
+                    experiment_ids=[exp.experiment_id],
+                    filter_string=f"params.git_hash = '{git_hash}'",
+                    max_results=50,
+                )
+                for run in runs:
+                    found_runs = True
+                    run_name = run.info.run_name or run.info.run_id[:8]
+                    for metric_key, metric_val in sorted(run.data.metrics.items()):
+                        val_str = f"{metric_val:.4f}" if isinstance(metric_val, float) else str(metric_val)
+                        lines.append(f"| {exp.name} | {run_name} | {metric_key} | {val_str} |")
+
+            if not found_runs:
+                lines.append(f"| - | - | No runs found for git_hash={git_hash} | - |")
+
+            lines.append("")
+            lines.append("> Detailed results: [MLflow Experiments](https://rhods-dashboard-redhat-ods-applications.{{ .Values.CLUSTER_DOMAIN }})")
+            lines.append("")
+
+            with open(summary_path, "w") as f:
+                f.write("\n".join(lines))
+            print(f"✅ KFP eval summary written to {summary_path}")
+
+        except Exception as e:
+            print(f"⚠️  Failed to query MLflow: {e}")
+            with open(summary_path, "w") as f:
+                f.write("### KFP Evaluations (MLflow)\n\n")
+                f.write(f"> ⚠️ Could not retrieve MLflow metrics: {e}\n")
+                f.write("> Check [MLflow Experiments](https://rhods-dashboard-redhat-ods-applications.{{ .Values.CLUSTER_DOMAIN }}) for details.\n")
+            print(f"⚠️  Fallback summary written to {summary_path}")
+
         PYEOF
   workspaces:
     - description: Workspace for pipeline files

--- a/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
@@ -139,6 +139,7 @@ spec:
             lines.append("|------------|-----|--------|-------|")
 
             found_runs = False
+            exp_links = []
             for exp in experiments:
                 exp_id = exp["experiment_id"]
                 exp_name = exp.get("name", exp_id)
@@ -153,19 +154,22 @@ spec:
                     continue
                 run = runs[0]
                 found_runs = True
-                run_name = run.get("info", {}).get("run_name", run["info"]["run_id"][:8])
+                mlflow_run_id = run["info"]["run_id"]
+                run_name = run.get("info", {}).get("run_name", mlflow_run_id[:8])
                 metrics = run.get("data", {}).get("metrics", [])
                 for m in sorted(metrics, key=lambda x: x["key"]):
                     val = m["value"]
                     val_str = f"{val:.4f}" if isinstance(val, float) else str(val)
                     lines.append(f"| {exp_name} | {run_name} | {m['key']} | {val_str} |")
+                exp_links.append(f"- [{exp_name}](https://rh-ai.{{ .Values.CLUSTER_DOMAIN }}/develop-train/mlflow/experiments/{exp_id}/runs/{mlflow_run_id}/evaluations?workspace={namespace})")
 
             if not found_runs:
                 lines.append(f"| - | - | No runs found for git_hash={git_hash} | - |")
 
             lines.append("")
-            rhoai_run_url = f"https://rh-ai.{{ .Values.CLUSTER_DOMAIN }}/develop-train/pipelines/runs/{namespace}/runs/{kfp_run_id}"
-            lines.append(f"> Detailed results: [OpenShift AI - Pipeline Run]({rhoai_run_url})")
+            lines.append("> Detailed results:")
+            for link in exp_links:
+                lines.append(f">   {link}")
             lines.append("")
 
             with open(summary_path, "w") as f:

--- a/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
@@ -123,6 +123,7 @@ spec:
             req = urllib.request.Request(url, data=data, method=method)
             req.add_header("Authorization", f"Bearer {bearer_token}")
             req.add_header("Content-Type", "application/json")
+            req.add_header("X-MLflow-Workspace", namespace)
             with urllib.request.urlopen(req, context=ctx) as resp:
                 return json.loads(resp.read().decode())
 
@@ -157,7 +158,7 @@ spec:
                 lines.append(f"| - | - | No runs found for git_hash={git_hash} | - |")
 
             lines.append("")
-            lines.append("> Detailed results: [MLflow Experiments](https://rhods-dashboard-redhat-ods-applications.{{ .Values.CLUSTER_DOMAIN }})")
+            lines.append("> Detailed results: [OpenShift AI Experiments](https://rhods-dashboard-redhat-ods-applications.{{ .Values.CLUSTER_DOMAIN }}/experiments)")
             lines.append("")
 
             with open(summary_path, "w") as f:
@@ -169,7 +170,7 @@ spec:
             with open(summary_path, "w") as f:
                 f.write("### KFP Evaluations (MLflow)\n\n")
                 f.write(f"> Could not retrieve MLflow metrics: {e}\n")
-                f.write("> Check [MLflow Experiments](https://rhods-dashboard-redhat-ods-applications.{{ .Values.CLUSTER_DOMAIN }}) for details.\n")
+                f.write("> Check [OpenShift AI Experiments](https://rhods-dashboard-redhat-ods-applications.{{ .Values.CLUSTER_DOMAIN }}/experiments) for details.\n")
             print(f"⚠️  Fallback summary written to {summary_path}")
 
         PYEOF

--- a/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
@@ -37,8 +37,8 @@ spec:
 
         ls -latr
 
-        echo "Installing KFP and MLflow dependencies..."
-        python3 -m pip install kfp==2.14.6 kfp.kubernetes==2.14.6 mlflow==2.21.3
+        echo "Installing KFP dependencies..."
+        python3 -m pip install kfp==2.14.6 kfp.kubernetes==2.14.6
 
         echo "Executing Kubeflow Pipeline..."
         python3 << 'PYEOF'
@@ -46,6 +46,9 @@ spec:
         import sys
         import os
         import time
+        import json
+        import urllib.request
+        import ssl
 
         sys.path.insert(0, '.')
 
@@ -103,23 +106,30 @@ spec:
         print(f"🎉 Pipeline run created with ID: {run_id.run_id}")
         print("✅ Kubeflow Pipeline execution completed successfully!")
 
-        # --- Phase 2: Query MLflow for evaluation metrics ---
+        # --- Phase 2: Query MLflow REST API for evaluation metrics ---
         print("📊 Querying MLflow for evaluation metrics...")
-        time.sleep(30)  # Allow MLflow to flush all metrics
+        time.sleep(30)
 
         workspace_path = "$(workspaces.output.path)"
         summary_path = os.path.join(workspace_path, "kfp_eval_summary.md")
 
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        def mlflow_api(endpoint, method="GET", body=None):
+            url = f"{mlflow_tracking_uri}{endpoint}"
+            data = json.dumps(body).encode() if body else None
+            req = urllib.request.Request(url, data=data, method=method)
+            req.add_header("Authorization", f"Bearer {bearer_token}")
+            req.add_header("Content-Type", "application/json")
+            with urllib.request.urlopen(req, context=ctx) as resp:
+                return json.loads(resp.read().decode())
+
         try:
-            import mlflow
-            from mlflow.tracking import MlflowClient
+            exp_resp = mlflow_api("/api/2.0/mlflow/experiments/search", "POST", {"max_results": 100})
+            experiments = exp_resp.get("experiments", [])
 
-            os.environ["MLFLOW_TRACKING_URI"] = mlflow_tracking_uri
-            os.environ["MLFLOW_TRACKING_TOKEN"] = bearer_token
-
-            mlflow_client = MlflowClient(tracking_uri=mlflow_tracking_uri)
-
-            experiments = mlflow_client.search_experiments()
             lines = []
             lines.append("### KFP Evaluations (MLflow)\n")
             lines.append("| Experiment | Run | Metric | Value |")
@@ -127,17 +137,21 @@ spec:
 
             found_runs = False
             for exp in experiments:
-                runs = mlflow_client.search_runs(
-                    experiment_ids=[exp.experiment_id],
-                    filter_string=f"params.git_hash = '{git_hash}'",
-                    max_results=50,
-                )
-                for run in runs:
+                exp_id = exp["experiment_id"]
+                exp_name = exp.get("name", exp_id)
+                runs_resp = mlflow_api("/api/2.0/mlflow/runs/search", "POST", {
+                    "experiment_ids": [exp_id],
+                    "filter": f"params.git_hash = '{git_hash}'",
+                    "max_results": 50,
+                })
+                for run in runs_resp.get("runs", []):
                     found_runs = True
-                    run_name = run.info.run_name or run.info.run_id[:8]
-                    for metric_key, metric_val in sorted(run.data.metrics.items()):
-                        val_str = f"{metric_val:.4f}" if isinstance(metric_val, float) else str(metric_val)
-                        lines.append(f"| {exp.name} | {run_name} | {metric_key} | {val_str} |")
+                    run_name = run.get("info", {}).get("run_name", run["info"]["run_id"][:8])
+                    metrics = run.get("data", {}).get("metrics", [])
+                    for m in sorted(metrics, key=lambda x: x["key"]):
+                        val = m["value"]
+                        val_str = f"{val:.4f}" if isinstance(val, float) else str(val)
+                        lines.append(f"| {exp_name} | {run_name} | {m['key']} | {val_str} |")
 
             if not found_runs:
                 lines.append(f"| - | - | No runs found for git_hash={git_hash} | - |")
@@ -154,7 +168,7 @@ spec:
             print(f"⚠️  Failed to query MLflow: {e}")
             with open(summary_path, "w") as f:
                 f.write("### KFP Evaluations (MLflow)\n\n")
-                f.write(f"> ⚠️ Could not retrieve MLflow metrics: {e}\n")
+                f.write(f"> Could not retrieve MLflow metrics: {e}\n")
                 f.write("> Check [MLflow Experiments](https://rhods-dashboard-redhat-ods-applications.{{ .Values.CLUSTER_DOMAIN }}) for details.\n")
             print(f"⚠️  Fallback summary written to {summary_path}")
 

--- a/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
@@ -145,16 +145,20 @@ spec:
                 runs_resp = mlflow_api("/api/2.0/mlflow/runs/search", "POST", {
                     "experiment_ids": [exp_id],
                     "filter": f"params.git_hash = '{git_hash}'",
-                    "max_results": 50,
+                    "order_by": ["start_time DESC"],
+                    "max_results": 1,
                 })
-                for run in runs_resp.get("runs", []):
-                    found_runs = True
-                    run_name = run.get("info", {}).get("run_name", run["info"]["run_id"][:8])
-                    metrics = run.get("data", {}).get("metrics", [])
-                    for m in sorted(metrics, key=lambda x: x["key"]):
-                        val = m["value"]
-                        val_str = f"{val:.4f}" if isinstance(val, float) else str(val)
-                        lines.append(f"| {exp_name} | {run_name} | {m['key']} | {val_str} |")
+                runs = runs_resp.get("runs", [])
+                if not runs:
+                    continue
+                run = runs[0]
+                found_runs = True
+                run_name = run.get("info", {}).get("run_name", run["info"]["run_id"][:8])
+                metrics = run.get("data", {}).get("metrics", [])
+                for m in sorted(metrics, key=lambda x: x["key"]):
+                    val = m["value"]
+                    val_str = f"{val:.4f}" if isinstance(val, float) else str(val)
+                    lines.append(f"| {exp_name} | {run_name} | {m['key']} | {val_str} |")
 
             if not found_runs:
                 lines.append(f"| - | - | No runs found for git_hash={git_hash} | - |")

--- a/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/kfp-evaluation-task.yaml
@@ -106,6 +106,8 @@ spec:
         print(f"🎉 Pipeline run created with ID: {run_id.run_id}")
         print("✅ Kubeflow Pipeline execution completed successfully!")
 
+        kfp_run_id = run_id.run_id
+
         # --- Phase 2: Query MLflow REST API for evaluation metrics ---
         print("📊 Querying MLflow for evaluation metrics...")
         time.sleep(30)
@@ -158,7 +160,8 @@ spec:
                 lines.append(f"| - | - | No runs found for git_hash={git_hash} | - |")
 
             lines.append("")
-            lines.append("> Detailed results: [OpenShift AI Experiments](https://rhods-dashboard-redhat-ods-applications.{{ .Values.CLUSTER_DOMAIN }}/experiments)")
+            rhoai_run_url = f"https://rh-ai.{{ .Values.CLUSTER_DOMAIN }}/develop-train/pipelines/runs/{namespace}/runs/{kfp_run_id}"
+            lines.append(f"> Detailed results: [OpenShift AI - Pipeline Run]({rhoai_run_url})")
             lines.append("")
 
             with open(summary_path, "w") as f:

--- a/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
@@ -114,24 +114,26 @@ spec:
             print("⚠️  No guidellm_eval_summary.md found, using fallback")
 
         # Compose the full PR body
-        body = f"""## Promote `vector_db_id: {vector_db_id}` to Production
-
-This PR was automatically created by the evals pipeline after all evaluations passed.
-
----
-
-## Evaluation Results
-
-{kfp_summary}
-
-{guidellm_summary}
-
----
-
-🔗 **Links:**
-- [Prompt Tracker](https://prompt-tracker-ai501.{cluster_domain}/{username}/{cluster_domain})
-- Commit: `{git_hash}`
-"""
+        body_parts = [
+            f"## Promote `vector_db_id: {vector_db_id}` to Production",
+            "",
+            "This PR was automatically created by the evals pipeline after all evaluations passed.",
+            "",
+            "---",
+            "",
+            "## Evaluation Results",
+            "",
+            kfp_summary,
+            "",
+            guidellm_summary,
+            "",
+            "---",
+            "",
+            f"🔗 **Links:**",
+            f"- [Prompt Tracker](https://prompt-tracker-ai501.{cluster_domain}/{username}/{cluster_domain})",
+            f"- Commit: `{git_hash}`",
+        ]
+        body = "\n".join(body_parts)
 
         # Create PR via Gitea API
         gitea_url = f"https://gitea-gitea.{cluster_domain}/api/v1/repos/{username}/genaiops-gitops/pulls"

--- a/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
@@ -130,7 +130,7 @@ spec:
             "---",
             "",
             f"🔗 **Links:**",
-            f"- [MinIO Test Results](https://minio-ui-{username}-toolings.{cluster_domain}/browser/test-results)",
+            f"- [MinIO Test Results](https://minio-ui-{username}-toolings.{cluster_domain}/browser/test-results/{git_hash}/)",
             f"- Commit: `{git_hash}`",
         ]
         body = "\n".join(body_parts)

--- a/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
@@ -10,32 +10,57 @@ spec:
     - name: WORK_DIRECTORY
       description: Directory to start build in (handle multiple branches)
       type: string
+    - name: USERNAME
+      description: Name of the team that doing this exercise :)
+      type: string
+    - name: VECTOR_DB_ID
+      description: Vector DB ID to promote to prod. If empty, no PR is raised.
+      type: string
   steps:
     - name: patch-vector-db-id
+      workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
+      image: quay.io/redhat-cop/tekton-task-helm:3.6.3
+      script: |
+        #!/bin/sh
+        vector_db_id="$(params.VECTOR_DB_ID)"
+
+        if [ -z "${vector_db_id}" ]; then
+          echo "⏭️  No VECTOR_DB_ID provided, nothing to promote to prod. Skipping."
+          exit 0
+        fi
+
+        yq eval -i .information-search.vector_db_id=\"${vector_db_id}\" config.yaml
+
+    - name: commit-and-raise-pr
       workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
       image: quay.io/redhat-cop/ubi8-git:latest
       script: |
         #!/bin/sh
+        vector_db_id="$(params.VECTOR_DB_ID)"
+
+        if [ -z "${vector_db_id}" ]; then
+          echo "⏭️  No VECTOR_DB_ID provided, nothing to promote to prod. Skipping."
+          exit 0
+        fi
+
         git pull
         git config --global user.email "tekton@mlops.bot.com"
         git config --global user.name "🐈 Tekton 🐈"
         git config --global push.default simple
         git config --global --add safe.directory '*'
-        branch_name=genaiops_$(date +%Y_%m_%d_%H_%M)
-        git checkout -b $branch_name
-        cp values-test.yaml values-prod.yaml
-        git add values-prod.yaml
-        git commit -m "🚀 AUTOMATED COMMIT - Production prompt is updated" || rc=$?
-        git remote set-url origin $(cat $HOME/.git-credentials)/{{ .Values.USER_NAME }}/backend.git
-        git push origin $branch_name
-        curl --location 'https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/api/v1/repos/{{ .Values.USER_NAME }}/backend/pulls' --user 'opentlc-mgr:myPassw0rd' --header 'accept: application/json' --header 'Content-Type: application/json' \
+        branch_name=promote-${vector_db_id}
+        git checkout -b ${branch_name}
+        git add config.yaml
+        git commit -m "🚀 AUTOMATED COMMIT - promote vector_db_id=${vector_db_id} to prod 🚀" || rc=$?
+        git remote set-url origin $(cat $HOME/.git-credentials)/$(params.USERNAME)/genaiops-gitops.git
+        git push origin ${branch_name}
+        curl --location "https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/api/v1/repos/$(params.USERNAME)/genaiops-gitops/pulls" --user 'opentlc-mgr:myPassw0rd' --header 'accept: application/json' --header 'Content-Type: application/json' \
           --data '{
-              "assignee": "{{ .Values.USER_NAME }}",
+              "assignee": "$(params.USERNAME)",
               "base": "main",
-              "body": "Evaluation results can be found in [Prompt Tracker](https://prompt-tracker-ai501.{{ .Values.CLUSTER_DOMAIN }}/{{ .Values.USER_NAME }}/{{ .Values.CLUSTER_DOMAIN }}).",
+              "body": "This PR promotes `vector_db_id: '"${vector_db_id}"'` to prod after it passed the evals pipeline.\n\nEvaluation results will be added to this PR in a follow-up. In the meantime, check [Prompt Tracker](https://prompt-tracker-ai501.{{ .Values.CLUSTER_DOMAIN }}/$(params.USERNAME)/{{ .Values.CLUSTER_DOMAIN }}) for details.",
               "head": "'${branch_name}'",
-              "title": "🚀 AUTOMATED PR - Production prompts updates 🚀"
+              "title": "🚀 AUTOMATED PR - Promote vector_db_id '"${vector_db_id}"' to prod 🚀"
           }'
 
-          echo "☘️ A pull request is raised for prod: https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/{{ .Values.USER_NAME }}/backend/pulls/"
-  
+        echo "☘️ A pull request is raised for prod: https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/$(params.USERNAME)/genaiops-gitops/pulls/"

--- a/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
@@ -130,7 +130,7 @@ spec:
             "---",
             "",
             f"🔗 **Links:**",
-            f"- [Prompt Tracker](https://prompt-tracker-ai501.{cluster_domain}/{username}/{cluster_domain})",
+            f"- [MinIO Test Results](https://minio-ui-{username}-toolings.{cluster_domain}/browser/test-results)",
             f"- Commit: `{git_hash}`",
         ]
         body = "\n".join(body_parts)

--- a/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
@@ -16,6 +16,10 @@ spec:
     - name: VECTOR_DB_ID
       description: Vector DB ID to promote to prod. If empty, no PR is raised.
       type: string
+    - name: GIT_SHORT_REVISION
+      description: Short git hash used for linking to eval reports
+      type: string
+      default: "latest"
   steps:
     - name: patch-vector-db-id
       workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
@@ -31,7 +35,7 @@ spec:
 
         yq eval -i .information-search.vector_db_id=\"${vector_db_id}\" config.yaml
 
-    - name: commit-and-raise-pr
+    - name: commit-and-push
       workingDir: $(workspaces.output.path)/$(params.WORK_DIRECTORY)
       image: quay.io/redhat-cop/ubi8-git:latest
       script: |
@@ -54,13 +58,120 @@ spec:
         git commit -m "🚀 AUTOMATED COMMIT - promote vector_db_id=${vector_db_id} to prod 🚀" || rc=$?
         git remote set-url origin $(cat $HOME/.git-credentials)/$(params.USERNAME)/genaiops-gitops.git
         git push origin ${branch_name}
-        curl --location "https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/api/v1/repos/$(params.USERNAME)/genaiops-gitops/pulls" --user 'opentlc-mgr:myPassw0rd' --header 'accept: application/json' --header 'Content-Type: application/json' \
-          --data '{
-              "assignee": "$(params.USERNAME)",
-              "base": "main",
-              "body": "This PR promotes `vector_db_id: '"${vector_db_id}"'` to prod after it passed the evals pipeline.\n\nEvaluation results will be added to this PR in a follow-up. In the meantime, check [Prompt Tracker](https://prompt-tracker-ai501.{{ .Values.CLUSTER_DOMAIN }}/$(params.USERNAME)/{{ .Values.CLUSTER_DOMAIN }}) for details.",
-              "head": "'${branch_name}'",
-              "title": "🚀 AUTOMATED PR - Promote vector_db_id '"${vector_db_id}"' to prod 🚀"
-          }'
 
-        echo "☘️ A pull request is raised for prod: https://gitea-gitea.{{ .Values.CLUSTER_DOMAIN }}/$(params.USERNAME)/genaiops-gitops/pulls/"
+        echo "${branch_name}" > /tmp/branch_name.txt
+        echo "✅ Branch ${branch_name} pushed successfully"
+
+    - name: create-pr-with-results
+      workingDir: $(workspaces.output.path)
+      image: registry.redhat.io/ubi9/python-311:latest
+      script: |
+        #!/bin/sh
+        set -e
+
+        vector_db_id="$(params.VECTOR_DB_ID)"
+
+        if [ -z "${vector_db_id}" ]; then
+          echo "⏭️  No VECTOR_DB_ID provided, nothing to promote to prod. Skipping."
+          exit 0
+        fi
+
+        python3 << 'PYEOF'
+        import json
+        import os
+        import urllib.request
+        import urllib.error
+        import base64
+        import ssl
+
+        vector_db_id = "$(params.VECTOR_DB_ID)"
+        username = "$(params.USERNAME)"
+        git_hash = "$(params.GIT_SHORT_REVISION)"
+        branch_name = f"promote-{vector_db_id}"
+        cluster_domain = "{{ .Values.CLUSTER_DOMAIN }}"
+        workspace_path = "$(workspaces.output.path)"
+
+        # Read KFP eval summary
+        kfp_summary = ""
+        kfp_path = os.path.join(workspace_path, "kfp_eval_summary.md")
+        if os.path.exists(kfp_path):
+            with open(kfp_path) as f:
+                kfp_summary = f.read().strip()
+            print(f"✅ Loaded KFP eval summary ({len(kfp_summary)} chars)")
+        else:
+            kfp_summary = "### KFP Evaluations (MLflow)\n\n> ⚠️ KFP evaluation summary not available for this run."
+            print("⚠️  No kfp_eval_summary.md found, using fallback")
+
+        # Read GuideLLM eval summary
+        guidellm_summary = ""
+        guidellm_path = os.path.join(workspace_path, "guidellm_eval_summary.md")
+        if os.path.exists(guidellm_path):
+            with open(guidellm_path) as f:
+                guidellm_summary = f.read().strip()
+            print(f"✅ Loaded GuideLLM eval summary ({len(guidellm_summary)} chars)")
+        else:
+            guidellm_summary = "### GuideLLM Benchmarks\n\n> ⚠️ GuideLLM benchmark summary not available for this run."
+            print("⚠️  No guidellm_eval_summary.md found, using fallback")
+
+        # Compose the full PR body
+        body = f"""## Promote `vector_db_id: {vector_db_id}` to Production
+
+This PR was automatically created by the evals pipeline after all evaluations passed.
+
+---
+
+## Evaluation Results
+
+{kfp_summary}
+
+{guidellm_summary}
+
+---
+
+🔗 **Links:**
+- [Prompt Tracker](https://prompt-tracker-ai501.{cluster_domain}/{username}/{cluster_domain})
+- Commit: `{git_hash}`
+"""
+
+        # Create PR via Gitea API
+        gitea_url = f"https://gitea-gitea.{cluster_domain}/api/v1/repos/{username}/genaiops-gitops/pulls"
+
+        pr_data = {
+            "assignee": username,
+            "base": "main",
+            "body": body,
+            "head": branch_name,
+            "title": f"🚀 AUTOMATED PR - Promote vector_db_id {vector_db_id} to prod 🚀"
+        }
+
+        payload = json.dumps(pr_data).encode("utf-8")
+        credentials = base64.b64encode(b"opentlc-mgr:myPassw0rd").decode("ascii")
+
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        req = urllib.request.Request(
+            gitea_url,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": f"Basic {credentials}",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, context=ctx) as resp:
+                result = json.loads(resp.read().decode())
+                pr_number = result.get("number", "?")
+                print(f"☘️ Pull request #{pr_number} created successfully!")
+                print(f"   URL: https://gitea-gitea.{cluster_domain}/{username}/genaiops-gitops/pulls/{pr_number}")
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else "no body"
+            print(f"❌ Failed to create PR: HTTP {e.code}")
+            print(f"   Response: {error_body}")
+            raise
+
+        PYEOF

--- a/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
+++ b/charts/canopy-evals-pipeline/templates/tasks/raise-pr.yaml
@@ -126,12 +126,6 @@ spec:
             kfp_summary,
             "",
             guidellm_summary,
-            "",
-            "---",
-            "",
-            f"🔗 **Links:**",
-            f"- [MinIO Test Results](https://minio-ui-{username}-toolings.{cluster_domain}/browser/test-results/{git_hash}/)",
-            f"- Commit: `{git_hash}`",
         ]
         body = "\n".join(body_parts)
 

--- a/charts/canopy-evals-pipeline/templates/triggers/triggers.yaml
+++ b/charts/canopy-evals-pipeline/templates/triggers/triggers.yaml
@@ -85,7 +85,7 @@ spec:
         name: "cel"
       params:
         - name: filter
-          value: (body.ref == 'refs/heads/main') && (header.match('X-GitHub-Event', 'push')) && ((body.repository.name == 'evals') || ((body.repository.name == 'genaiops-gitops') && body.commits.exists(c, c.modified.exists(m, m == 'canopy/test/backend/config.yaml'))))
+          value: (body.ref == 'refs/heads/main') && (header.match('X-GitHub-Event', 'push') || header.match('X-Gitea-Event', 'push')) && ((body.repository.name == 'evals') || ((body.repository.name == 'genaiops-gitops') && body.commits.exists(c, c.modified.exists(m, m == 'canopy/test/backend/config.yaml'))))
         - name: overlays
           value:
           - expression: body.head_commit.id.truncate(7)

--- a/charts/canopy-evals-pipeline/templates/triggers/triggers.yaml
+++ b/charts/canopy-evals-pipeline/templates/triggers/triggers.yaml
@@ -17,6 +17,9 @@ spec:
     - name: git-ref
       description: The full git ref
       default: refs/heads/main
+    - name: vector-db-id
+      description: Vector DB ID extracted from the triggering commit message
+      default: ""
     - name: webhook-action
       default: ""
     - name: webhook-entity
@@ -44,6 +47,8 @@ spec:
         params:
           - name: GIT_SHORT_REVISION
             value: $(tt.params.git-short-revision)
+          - name: VECTOR_DB_ID
+            value: $(tt.params.vector-db-id)
           - name: BACKEND_URL
             value: {{ .Values.kfp.backendUrl | quote }}
           - name: LLM_ENDPOINT
@@ -87,11 +92,15 @@ spec:
             key: truncated_sha
           - expression: body.ref.split('/')[2]
             key: branch_name
+          - expression: "body.head_commit.message.contains('vector_db_id=') ? body.head_commit.message.split('vector_db_id=')[1].split(' ')[0] : ''"
+            key: vector_db_id
   bindings:
     - name: git-ref
       value: $(body.ref)
     - name: git-short-revision
       value: $(extensions.truncated_sha)
+    - name: vector-db-id
+      value: $(extensions.vector_db_id)
   template:
     ref: canopy-evals-trigger-template
 


### PR DESCRIPTION
## Summary

Adds Phase 1 + Phase 2 improvements to the `canopy-evals-pipeline`:

**Phase 1 — Automated PR to production:** PR: https://github.com/rhoai-genaiops/genaiops-helmcharts/pull/46
- Pipeline raises a PR to `genaiops-gitops` after all evaluations pass
- PR includes `vector_db_id` and commit reference
- Evals trigger accepts both GitHub and Gitea webhook headers

**Phase 2 — Evaluation metrics embedded in PR body:**
- KFP evaluation task queries MLflow REST API (with `X-MLflow-Workspace` header) for the latest metrics per experiment filtered by `git_hash`
- GuideLLM task generates a markdown summary table with throughput, latency, TTFT per endpoint
- `raise-pr` task reads both summaries from shared workspace and composes a rich PR body
- Direct links to each MLflow experiment run (overview page) in RHOAI dashboard
- Link to MinIO `test-results` bucket with folder reference

**Files changed:**
- `pipeline.yaml` — wires `GIT_SHORT_REVISION` and orchestrates task dependencies
- `kfp-evaluation-task.yaml` — MLflow REST API query + markdown summary generation
- `guidellm-task.yaml` — benchmark result parsing + markdown summary step
- `raise-pr.yaml` — rewritten to compose PR body from eval summaries via Python
- `triggers.yaml` — accepts `X-Gitea-Event` header

## Dependencies
This PR depends on https://github.com/rhoai-genaiops/lab-instructions/pull/191

## Test plan
- [x] Helm template renders without errors
- [x] Full E2E pipeline run with real KFP evaluations and GuideLLM benchmarks
- [x] PR body contains correct metrics, links to MLflow runs, and MinIO reference
- [x] Triggered real flow: new doc → doc-ingestion → evals → PR with new commit (`148213f`)
- [x] MLflow links navigate to correct experiment run overview
- [x] Only latest MLflow run per experiment shown (no duplicates)

## Test evidence

<img width="1097" height="489" alt="image" src="https://github.com/user-attachments/assets/3bcebcfe-2c0f-4d9f-add1-ee137a09322a" />

<img width="759" height="286" alt="image" src="https://github.com/user-attachments/assets/ea06e310-857e-4852-9ff7-9906cd0fee8a" />

<img width="1305" height="948" alt="image" src="https://github.com/user-attachments/assets/8b2c9418-a3b1-4a81-96d7-c63fb1c9adf6" />

Made with [Cursor](https://cursor.com)