### PR TITLE
Fixing inability to access settings on token-visualizer

### DIFF
--- a/charts/token-visualizer/src/index.html
+++ b/charts/token-visualizer/src/index.html
@@ -24,6 +24,7 @@
             justify-content: center;
             align-items: center;
             overflow: hidden;
+            overflow-y: auto;
         }
 
         .container {


### PR DESCRIPTION
Overflow on the y axis is hidden in token visualizer making it impossible to see the settings if the window is small.